### PR TITLE
Add Value Based Exclusion for Environment Variables and Secrets

### DIFF
--- a/application/main.tf
+++ b/application/main.tf
@@ -16,16 +16,10 @@ locals {
   common_advanced              = lookup(lookup(var.values, "advanced", {}), "common", {})
   all_secrets                  = lookup(local.common_advanced, "include_common_env_secrets", false) ? var.environment.secrets : {}
   advanced_config              = lookup(local.common_advanced, "app_chart", {})
-  common_environment_variables = var.environment.common_environment_variables
+  common_environment_variables = jsondecode(lookup(local.common_advanced, "include_common_env_variables", false) ? jsonencode(var.environment.common_environment_variables) : jsonencode({}))
   spec_environment_variables   = lookup(var.values.spec, "env", {})
-  include_common_env_variables = lookup(var.values.advanced.common, "include_common_env_variables", false)
-  common_env_vars = var.environment.common_environment_variables
-
-  env_vars = jsondecode(
-    local.include_common_env_variables
-    ? jsonencode(merge(local.common_env_vars, local.spec_environment_variables))
-    : jsonencode(local.spec_environment_variables)
-  )
+  env_vars                     = merge(local.common_environment_variables, local.spec_environment_variables)
+  env_vars_str                 = {for key,value in local.env_vars: key => "${value}"}
   deployment_id                = lookup(local.common_advanced, "pass_deployment_id", false) ? var.environment.deployment_id : ""
   taints                       = lookup(local.kubernetes_node_pool_details, "taints", [])
   chart_name                   = lookup(lookup(lookup(var.values, "metadata", {}), "labels", {}), "resourceName", var.chart_name)
@@ -97,14 +91,13 @@ locals {
   } : lookup(local.advanced_config_values, "pod_distribution", {}) : null
   sidecars        = lookup(var.values.spec, "sidecars", lookup(local.advanced_config_values, "sidecars", {}))
   init_containers = lookup(var.values.spec, "init_containers", lookup(local.advanced_config_values, "init_containers", {}))
-
   exclude_env_and_secret_values = try(
     var.values.advanced.common.app_chart.values.exclude_env_and_secret_values,
     []
   )
 
   filtered_env_vars = {
-    for k, v in local.env_vars :
+    for k, v in local.env_vars_str :
     k => v
     if !(contains(local.exclude_env_and_secret_values, v))
   }
@@ -114,13 +107,6 @@ locals {
     k => v
     if !(contains(local.exclude_env_and_secret_values, v))
   }
-
-  final_env = merge(
-    local.filtered_env_vars,
-    local.build_id_env,
-    (local.deployment_id != "" ? { DEPLOYMENT_ID = local.deployment_id } : {}),
-    local.filtered_all_secrets
-  )
 }
 
 resource "helm_release" "app-chart" {
@@ -164,7 +150,13 @@ resource "helm_release" "app-chart" {
     }),
     yamlencode({
       spec = {
-        env = local.final_env
+        env = merge(
+          lookup(local.dep_cluster, "globalVariables", {}),
+          local.filtered_env_vars,
+          local.build_id_env,
+          local.filtered_all_secrets,
+          length(local.deployment_id) > 0 ? { deployment_id = local.deployment_id } : {}
+        )
       }
     }),
     yamlencode({
@@ -184,10 +176,6 @@ resource "helm_release" "app-chart" {
       }
     })
   ]
-
-  lifecycle {
-    ignore_changes = [chart]
-  }
 }
 
 module "sts-pvc" {


### PR DESCRIPTION
Terraform module that allows users to exclude specific environment variables and secrets based on their values. The exclusion list is configurable via the input variable advanced.common.app_chart.values.exclude_env_and_secret_values. The update adds logic to filter out specific environment variables and secrets from being merged into Helm release values based on an exclusion list. This is achieved by defining new local variables that exclude entries with values specified in the exclusion list, affecting only the internal configuration of the Terraform module. 
same as : https://github.com/Facets-cloud/facets-iac/pull/1840