### PR TITLE
feat(aws_irsa): expose max_session_duration variable

### DIFF
--- a/aws_irsa/main.tf
+++ b/aws_irsa/main.tf
@@ -1,9 +1,10 @@
 
 
 module "iam_eks_role" {
-  source           = "./iam-role-for-service-accounts-eks"
-  role_name        = var.iam_role_name
-  role_policy_arns = { for k, v in var.iam_arns : k => v.arn }
+  source               = "./iam-role-for-service-accounts-eks"
+  role_name            = var.iam_role_name
+  role_policy_arns     = { for k, v in var.iam_arns : k => v.arn }
+  max_session_duration = var.max_session_duration
   oidc_providers = {
     one = {
       provider_arn               = var.eks_oidc_provider_arn

--- a/aws_irsa/variables.tf
+++ b/aws_irsa/variables.tf
@@ -17,3 +17,9 @@ variable "sa_name" {
 variable "eks_oidc_provider_arn" {
   type = string
 }
+
+variable "max_session_duration" {
+  description = "Maximum CLI/API session duration in seconds between 3600 and 43200"
+  type        = number
+  default     = 3600
+}


### PR DESCRIPTION
## Summary

- Added `max_session_duration` variable to `aws_irsa/variables.tf` (type: `number`, default: `3600`)
- Wired it through to the `iam-role-for-service-accounts-eks` submodule in `aws_irsa/main.tf`

## Why

The inner `iam-role-for-service-accounts-eks` submodule already supported `max_session_duration` but it was not exposed at the `aws_irsa` wrapper level. Callers that pass `max_session_duration` (e.g. service modules using IRSA) were getting `Unsupported argument` errors at plan time.

## Test plan

- [ ] Verify `terraform validate` passes on a module that passes `max_session_duration` to `aws_irsa`
- [ ] Confirm the IAM role is created with the expected session duration
- [ ] Confirm existing callers that do not pass `max_session_duration` still work (defaults to `3600`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable maximum session duration for AWS CLI/API authentication sessions (defaults to 3600 seconds, adjustable between 3600–43200 seconds).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->