### PR TITLE
feat(nginx_gateway_fabric): add legacy_resource_details output

### DIFF
--- a/nginx_gateway_fabric/outputs.tf
+++ b/nginx_gateway_fabric/outputs.tf
@@ -125,3 +125,29 @@ output "tenant_base_domain_id" {
   value       = local.tenant_base_domain_id
   description = "Route53 zone ID for the tenant base domain (empty if not AWS)"
 }
+
+output "legacy_resource_details" {
+  value = concat(
+    lookup(var.instance.spec, "basic_auth", false) ? [{
+      name          = "Basic Authentication Password"
+      value         = local.password
+      resource_type = "ingress"
+      resource_name = var.instance_name
+      key           = var.instance_name
+    }] : [],
+    lookup(var.instance.spec, "disable_base_domain", false) ? [] : [{
+      name          = "Base Domain"
+      value         = local.base_domain
+      resource_type = "ingress"
+      resource_name = var.instance_name
+      key           = var.instance_name
+    }],
+    [for k, v in lookup(var.instance.spec, "rules", {}) : {
+      name          = "ingress domain"
+      value         = lookup(v, "domain_prefix", null) == null || lookup(v, "domain_prefix", null) == "" ? local.base_domain : "${lookup(v, "domain_prefix", null)}.${local.base_domain}"
+      resource_type = "ingress_rules_infra"
+      resource_name = k
+      key           = k
+    }]
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `output "legacy_resource_details"` to `nginx_gateway_fabric` so ingress values (basic auth password, base domain, per-rule domains) show up in the Facets UI resource-values panel after release. Without this output the upstream `lookup(local.module_<key>, "legacy_resource_details", [])` in `level2/legacy.tf` falls back to `[]` and the UI shows nothing.
- Shape matches `modules/nginx_ingress_controller/0.2/main.tf:580` in `facets-iac` (the canonical legacy ingress module).
- Hardened against "inconsistent final plan" errors:
  - Branch conditions use `lookup(spec, "basic_auth", false)` and `lookup(spec, "disable_base_domain", false)` (input-derived, fully known at plan), so list lengths are deterministic. Avoids the unknown-at-plan length that would result from using `local.is_auth_enabled` (which depends on `length(local.password)`, unknown until `random_string` is generated on first apply).
  - All three concatenated arms produce objects with identical 5-string-attribute shape.
  - No `for_each`/`count` over unknown values.

## Test plan
- [ ] Apply on an environment with `basic_auth: true` and confirm the Facets UI shows the generated password under the ingress resource.
- [ ] Apply on an environment with `disable_base_domain: true` and confirm Base Domain entry is omitted (only per-rule domains shown).
- [ ] Apply on an environment with multiple `spec.rules` entries and confirm one `ingress domain` row per rule, with `domain_prefix` correctly prepended.
- [ ] First-time apply (random_string created) succeeds without "Provider produced inconsistent final plan".
- [ ] Re-apply (no spec change) shows no diff on the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New output now provides consolidated resource configuration details, including authentication settings, base domain information, and per-rule routing domain mappings, enabling easier access to deployed infrastructure metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->