### PR TITLE
feat(any-k8s-resource): make create_namespace configurable via advanced_config

### DIFF
--- a/any-k8s-resource/main.tf
+++ b/any-k8s-resource/main.tf
@@ -8,7 +8,7 @@ resource "helm_release" "k8s-resource" {
   wait             = lookup(var.advanced_config, "wait", false)
   max_history      = lookup(var.advanced_config, "max_history", 10)
   version          = "0.1.0"
-  create_namespace = true
+  create_namespace = lookup(var.advanced_config, "create_namespace", true)
   namespace        = var.namespace
   values = [
     yamlencode({


### PR DESCRIPTION
## Summary
- Make `create_namespace` on the wrapped `helm_release` configurable via `advanced_config.create_namespace`
- Defaults to `true` so existing callers see no behavior change

## Why
When the target namespace already exists and is managed externally — e.g. by a Kyverno policy that enforces required labels (`istio.io/dataplane-mode=ambient`, `istio.io/use-waypoint=waypoint`) — helm's `create_namespace=true` still sends a Namespace CREATE request to the API server. Kyverno's `ValidatingAdmissionWebhook` runs before the API server's existence check and rejects the candidate Namespace object (which helm emits without labels), even though the existing namespace satisfies the policy.

Hit this while deploying a demo to the CoinSwitch `common-uat` cluster — the `csx` and `default` namespaces already carry the required labels, but every helm release of an `ExternalSecret` CR (rendered via this module) was being rejected by `require-istio-ambient-labels`.

## Behavior
- Default unchanged: `create_namespace = true`
- Opt-out: caller passes `advanced_config = { create_namespace = false }`
- No new variable — uses the existing `advanced_config` map

## Test plan
- [ ] Verify existing consumers (no `advanced_config.create_namespace` set) still pass `create_namespace=true` to helm
- [ ] Verify `advanced_config = { create_namespace = false }` flips it to false
- [ ] Re-run the CoinSwitch demo deployment with `create_namespace=false` and confirm the Kyverno admission no longer rejects the helm release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Made Kubernetes namespace creation configurable through advanced settings instead of always being enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->