### PR TITLE
feat(nginx_gateway_fabric): add path to output_interfaces

### DIFF
--- a/nginx_gateway_fabric/locals.tf
+++ b/nginx_gateway_fabric/locals.tf
@@ -2,6 +2,7 @@ locals {
   username        = lookup(var.instance.spec, "basic_auth", false) ? "${var.instance_name}user" : ""
   password        = lookup(var.instance.spec, "basic_auth", false) && length(random_string.basic_auth_password) > 0 ? random_string.basic_auth_password[0].result : ""
   is_auth_enabled = length(local.username) > 0 && length(local.password) > 0
+  auth_prefix     = local.is_auth_enabled ? "${local.username}:${local.password}@" : ""
 
   output_attributes = merge(
     {
@@ -31,20 +32,17 @@ locals {
     for route_key, route in local.rulesFiltered : {
       for domain_key, domain in local.domains :
       "${route_key}--${domain_key}" => {
-        connection_string = local.is_auth_enabled ? "https://${local.username}:${local.password}@${
-          lookup(route, "domain_prefix", null) == null || lookup(route, "domain_prefix", null) == "" ?
-          domain.domain :
-          "${lookup(route, "domain_prefix", null)}.${domain.domain}"
-          }" : "https://${
-          lookup(route, "domain_prefix", null) == null || lookup(route, "domain_prefix", null) == "" ?
-          domain.domain :
-          "${lookup(route, "domain_prefix", null)}.${domain.domain}"
-        }"
         host = (
           lookup(route, "domain_prefix", null) == null || lookup(route, "domain_prefix", null) == "" ?
           domain.domain :
           "${lookup(route, "domain_prefix", null)}.${domain.domain}"
         )
+        connection_string = "https://${local.auth_prefix}${
+          lookup(route, "domain_prefix", null) == null || lookup(route, "domain_prefix", null) == "" ?
+          domain.domain :
+          "${lookup(route, "domain_prefix", null)}.${domain.domain}"
+        }"
+        path     = replace(lookup(route, "path", "/"), "/[*$^]/", "")
         port     = 443
         username = local.username
         password = local.password


### PR DESCRIPTION
## Summary
- Adds `path` field to `output_interfaces` in `nginx_gateway_fabric` module, stripping regex anchors (`*`, `$`, `^`) for clean path output
- Simplifies `connection_string` construction using an `auth_prefix` local instead of duplicated ternary logic
- Aligns with [facets-iac#2089](https://github.com/Facets-cloud/facets-iac/pull/2089) which adds the same fix to `nginx_k8s_native` and `nginx_ingress_controller`

## Test plan
- [ ] Verify `output_interfaces` includes `path` for each rule × domain entry
- [ ] Verify `connection_string` is unchanged for both auth-enabled and auth-disabled cases
- [ ] Verify path defaults to `/` when no path is set on the route
- [ ] Verify regex chars are stripped from paths (e.g. `/api/v1/*` → `/api/v1/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of gateway connection URLs when basic authentication is enabled.
  * Credentials are now inserted into endpoint URLs more consistently, reducing the chance of malformed links.
  * Existing authentication behavior remains unchanged for non-authenticated routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->