### PR TITLE
fix(nginx_gateway_fabric): emit apex listener for cert_ref domains (DNS-01)

### DIFF
--- a/nginx_gateway_fabric/main.tf
+++ b/nginx_gateway_fabric/main.tf
@@ -87,6 +87,9 @@ locals {
   # Filter rules
   rulesFiltered = {
     for k, v in local.rulesRaw : length(k) < 175 ? k : md5(k) => merge(v, {
+      # A rule with no domain_prefix is bound to the apex (bare) domain; otherwise
+      # to a subdomain. This drives both its hostname and which listener it attaches to.
+      is_apex    = lookup(v, "domain_prefix", null) == null || lookup(v, "domain_prefix", null) == ""
       host       = lookup(v, "domain_prefix", null) == null || lookup(v, "domain_prefix", null) == "" ? "${local.base_domain}" : "${lookup(v, "domain_prefix", null)}.${local.base_domain}"
       domain_key = "facets"
       namespace  = lookup(v, "namespace", var.environment.namespace)
@@ -140,6 +143,26 @@ locals {
     # Exclude subdomains of domains with certificate_reference (covered by wildcard listener)
     if !anytrue([for parent_domain, cert_ref in local.domains_with_cert_ref : endswith(hostname, ".${parent_domain}")])
   }
+
+  # Per-domain HTTPS listeners for the Gateway (cert-manager mode; flat data only,
+  # rendered into listener objects in the Gateway resource below).
+  #
+  # A domain with a certificate_reference (DNS-01 / external cert) has a cert whose
+  # SANs cover BOTH the apex and the wildcard (dnsNames = [domain, *.domain]), so it
+  # gets TWO listeners: a wildcard listener (https-<key>) for subdomains and an apex
+  # listener (https-<key>-apex) for the bare domain. Without the apex listener, rules
+  # with no domain_prefix have no listener to attach to. A plain cert-manager domain
+  # (no cert_ref) keeps a single apex listener whose cert this module issues.
+  https_domain_listeners = flatten([
+    for domain_key, domain in local.domains : (
+      lookup(domain, "certificate_reference", "") != "" ? [
+        { name = "https-${domain_key}", hostname = "*.${domain.domain}", secret = domain.certificate_reference },
+        { name = "https-${domain_key}-apex", hostname = domain.domain, secret = domain.certificate_reference },
+        ] : [
+        { name = "https-${domain_key}", hostname = domain.domain, secret = "${local.name}-${domain_key}-tls-cert" },
+      ]
+    ) if can(domain.domain)
+  ])
 
   # Nodepool configuration
   nodepool_config_raw = lookup(var.inputs, "kubernetes_node_pool_details", null)
@@ -311,17 +334,18 @@ locals {
             }] : (
             # Default (non-external-TLS): original logic with both listeners
             concat(
-              lookup(v, "domain_prefix", null) == null || lookup(v, "domain_prefix", null) == "" ? [
+              # One HTTPS parentRef per domain. An apex rule (no domain_prefix) attaches to
+              # the domain's apex listener; a subdomain rule attaches to the wildcard
+              # listener (cert_ref domains) or its per-hostname listener (cert-manager).
+              [
                 for domain_key, domain in local.domains : {
-                  name        = local.name
-                  namespace   = var.environment.namespace
-                  sectionName = "https-${domain_key}"
-                }
-                ] : [
-                for domain_key, domain in local.domains : {
-                  name        = local.name
-                  namespace   = var.environment.namespace
-                  sectionName = lookup(domain, "certificate_reference", "") != "" ? "https-${domain_key}" : "https-${replace(replace("${lookup(v, "domain_prefix", null)}.${domain.domain}", ".", "-"), "*", "wildcard")}"
+                  name      = local.name
+                  namespace = var.environment.namespace
+                  sectionName = lookup(domain, "certificate_reference", "") != "" ? (
+                    v.is_apex ? "https-${domain_key}-apex" : "https-${domain_key}"
+                    ) : (
+                    v.is_apex ? "https-${domain_key}" : "https-${replace(replace("${lookup(v, "domain_prefix", null)}.${domain.domain}", ".", "-"), "*", "wildcard")}"
+                  )
                 }
               ],
               !local.force_ssl_redirection ? [{
@@ -548,17 +572,18 @@ locals {
               sectionName = "http"
             }] : (
             concat(
-              lookup(v, "domain_prefix", null) == null || lookup(v, "domain_prefix", null) == "" ? [
+              # One HTTPS parentRef per domain. An apex rule (no domain_prefix) attaches to
+              # the domain's apex listener; a subdomain rule attaches to the wildcard
+              # listener (cert_ref domains) or its per-hostname listener (cert-manager).
+              [
                 for domain_key, domain in local.domains : {
-                  name        = local.name
-                  namespace   = var.environment.namespace
-                  sectionName = "https-${domain_key}"
-                }
-                ] : [
-                for domain_key, domain in local.domains : {
-                  name        = local.name
-                  namespace   = var.environment.namespace
-                  sectionName = lookup(domain, "certificate_reference", "") != "" ? "https-${domain_key}" : "https-${replace(replace("${lookup(v, "domain_prefix", null)}.${domain.domain}", ".", "-"), "*", "wildcard")}"
+                  name      = local.name
+                  namespace = var.environment.namespace
+                  sectionName = lookup(domain, "certificate_reference", "") != "" ? (
+                    v.is_apex ? "https-${domain_key}-apex" : "https-${domain_key}"
+                    ) : (
+                    v.is_apex ? "https-${domain_key}" : "https-${replace(replace("${lookup(v, "domain_prefix", null)}.${domain.domain}", ".", "-"), "*", "wildcard")}"
+                  )
                 }
               ],
               !local.force_ssl_redirection ? [{
@@ -1292,17 +1317,18 @@ resource "helm_release" "nginx_gateway_fabric" {
                 }
               }
             }] : [],
-            # cert-manager mode: per-domain HTTPS listeners with TLS termination at Gateway
-            var.external_tls_termination ? [] : [for domain_key, domain in local.domains : {
-              name     = "https-${domain_key}"
+            # cert-manager mode: per-domain HTTPS listeners (see local.https_domain_listeners
+            # for the apex-vs-wildcard rationale).
+            var.external_tls_termination ? [] : [for l in local.https_domain_listeners : {
+              name     = l.name
               protocol = "HTTPS"
               port     = 443
-              hostname = lookup(domain, "certificate_reference", "") != "" ? "*.${domain.domain}" : domain.domain
+              hostname = l.hostname
               tls = {
                 mode = "Terminate"
                 certificateRefs = [{
                   kind = "Secret"
-                  name = lookup(domain, "certificate_reference", "") != "" ? domain.certificate_reference : "${local.name}-${domain_key}-tls-cert"
+                  name = l.secret
                 }]
               }
               allowedRoutes = {
@@ -1310,7 +1336,7 @@ resource "helm_release" "nginx_gateway_fabric" {
                   from = "All"
                 }
               }
-            } if can(domain.domain)],
+            }],
             # cert-manager mode: HTTPS Listeners for additional hostnames
             var.external_tls_termination ? [] : [for hostname_key, config in local.additional_hostname_configs : {
               name     = "https-${hostname_key}"


### PR DESCRIPTION
## Problem
In cert-manager mode the Gateway emitted only a **wildcard** listener (`*.<domain>`) for any domain with a `certificate_reference`. In **DNS-01** mode the wrapper (`nginx_gateway_fabric_legacy_aws`, etc.) sets `certificate_reference` to the issued secret on every DNS-01 domain — including the base domain — whose cert SANs cover **both** apex and wildcard (`dnsNames = [domain, *.domain]`).

With no apex listener, HTTPRoutes for rules **without a `domain_prefix`** (host = apex) had no listener to attach to and were rejected (`Accepted=False`). Observed live: apex `https://<base_domain>` 404/refused while `*.<base_domain>` subdomains worked.

## Fix
- For `cert_ref` domains, emit **two** listeners — wildcard (`https-<key>`, subdomains) and apex (`https-<key>-apex`, bare domain) — sharing the same secret.
- Add `is_apex` to each rule; route apex rules to the apex listener and subdomain rules to the wildcard listener via `sectionName`.
- Plain cert-manager domains (no `cert_ref`) unchanged: single apex listener.
- Listener construction extracted into `local.https_domain_listeners`; the two `parentRef` branches collapsed into one expression for readability.

## Why it's safe
- **Additive** — wildcard listener keeps its name/hostname; apex listener is new. Nothing renamed/removed, so no working route loses its listener.
- saas-dev (all rules prefixed → subdomains) is **unchanged**; only ingresses with apex rules gain the new listener.
- ACM mode (`external_tls_termination`) is untouched.
- No double-attach: `*.domain` does not match the apex (Gateway API single-label wildcard), and `sectionName` is pinned.

## Notes / caveats
- Listener count for `cert_ref` domains goes **1 → 2** (scales linearly with domain count).
- An externally-supplied **wildcard-only** cert + an apex rule would see a cert SAN mismatch on the apex listener — but that route is already broken today (404), so not a regression. DNS-01 certs cover the apex, so the common path is a pure fix.

## Parent modules
No change needed in `nginx_gateway_fabric_legacy_aws/azure/gcp` — they're thin wrappers; all listener/route logic lives here, so they inherit the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved domain-based routing for HTTP and gRPC traffic with more precise HTTPS listener handling.
  * Added support for both apex and wildcard/subdomain TLS endpoints where needed.

* **Bug Fixes**
  * Routes now attach to the correct HTTPS listener for each domain, reducing misrouting and TLS attachment issues.
  * TLS listener generation is more consistent across domain configurations, including certificate-managed setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->