### PR TITLE
add lookup for default tolerations

### DIFF
--- a/application/2.0/main.tf
+++ b/application/2.0/main.tf
@@ -44,7 +44,7 @@ locals {
       value    = toleration.value
     }
   ]
-  all_tolerations = distinct(concat(local.adv_tolerations, local.parsed_taints, var.environment.default_tolerations))
+  all_tolerations = distinct(concat(local.adv_tolerations, local.parsed_taints, lookup(var.environment, "default_tolerations", [])))
 
   size = lookup(lookup(var.values.spec, "runtime", {}), "size", {
     cpu          = "1000m"

--- a/application/main.tf
+++ b/application/main.tf
@@ -52,7 +52,7 @@ locals {
       value    = toleration.value
     }
   ]
-  all_tolerations = concat(local.adv_tolerations, local.parsed_taints, var.environment.default_tolerations)
+  all_tolerations = concat(local.adv_tolerations, local.parsed_taints, lookup(var.environment, "default_tolerations", []))
 
   size = lookup(lookup(var.values.spec, "runtime", {}), "size", {
     cpu          = "1000m"

--- a/postgres_database/main.tf
+++ b/postgres_database/main.tf
@@ -60,7 +60,7 @@ resource "kubernetes_job" "postgres-database" {
           ]
         }
         dynamic "toleration" {
-          for_each = concat(var.environment.default_tolerations, var.inputs.kubernetes_details.attributes.legacy_outputs.facets_dedicated_tolerations, var.tolerations)
+          for_each = concat(lookup(var.environment, "default_tolerations", []), var.inputs.kubernetes_details.attributes.legacy_outputs.facets_dedicated_tolerations, var.tolerations)
           content {
             key      = lookup(toleration.value, "key", null)
             operator = lookup(toleration.value, "operator", "Equal")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for environments without default toleration settings.
  * Kubernetes workloads now continue deploying when `default_tolerations` is not configured.
  * Existing advanced, legacy, and explicitly configured tolerations remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->